### PR TITLE
Fix nodejs integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/*.a
+**/*.node
+**/*.rs.bk
+**/*.so
+**/*.swo
+**/*.swp
+**/node_modules
+**/package-lock.json
+**/swig_wrap.cxx
+/ffi/nodejs/build
+/ffi/nodejs/Dockerfile
+/rust-lib/rgb_node.h
+/rust-lib/target

--- a/demo/nodejs/example.js
+++ b/demo/nodejs/example.js
@@ -1,4 +1,4 @@
-const ex = require('./build/Release/rgb_node');
+const ex = require('../../ffi/nodejs/build/Release/rgb_node');
 
 const config = {
     network: "testnet",

--- a/ffi/nodejs/Dockerfile
+++ b/ffi/nodejs/Dockerfile
@@ -1,8 +1,7 @@
 FROM rustlang/rust:nightly-slim as builder
 
-COPY ffi /rgb-node/ffi
-COPY src /rgb-node/src
-COPY Cargo.lock Cargo.toml README.md /rgb-node/
+COPY ffi/nodejs /rgb-sdk/ffi/nodejs
+COPY rust-lib /rgb-sdk/rust-lib
 
 RUN apt-get update -y \
     && apt-get install -y \
@@ -30,7 +29,7 @@ RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | 
     nvm install v10 --lts && \
     nvm alias default v10
 
-WORKDIR /rgb-node/ffi/nodejs
+WORKDIR /rgb-sdk/ffi/nodejs
 
 RUN . $HOME/.nvm/nvm.sh && npm install --unsafe-perm
 
@@ -46,10 +45,9 @@ RUN apt-get update -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN mkdir -pv /rgb-node/target/debug/
-RUN mkdir -pv /rgb-node/ffi/nodejs/
+RUN mkdir -p /rgb-sdk/target/debug/ /rgb-sdk/ffi/nodejs/
 
-COPY --from=builder /rgb-node/ffi/nodejs/build/Release/rgb_node.node /rgb-node
-COPY --from=builder /rgb-node/target/debug/librgb.so /rgb-node/target/debug/
+COPY --from=builder /rgb-sdk/ffi/nodejs/build/Release/rgb_node.node /rgb-sdk/
+COPY --from=builder /rgb-sdk/rust-lib/target/debug/librgb.so /rgb-sdk/target/debug/
 
-WORKDIR /rgb-node/
+WORKDIR /rgb-sdk/

--- a/ffi/nodejs/README.md
+++ b/ffi/nodejs/README.md
@@ -2,19 +2,20 @@
 
 ## Build
 
-In order to build Node.js bindings, from the project root run:
+In order to build Node.js bindings, from the project root follow the _Local_ or
+_In docker_ instructions.
+
+Both instructions will generate the files `librgb.so` in `target/debug/`
+and `rgb_node.node` in `ffi/nodejs/build/Release/`.
 
 ### Local
 
 ```bash
 sudo apt install -y swig node-gyp
-cd ffi
-cargo build --release
-cd nodejs
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
 nvm install v10
+cd ffi/nodejs
 npm install
-node example.js
 ```
 
 ### In docker
@@ -26,4 +27,12 @@ docker run --rm -v $(pwd):/opt/mount --entrypoint bash \
     rgb-sdk-nodejs \
     -c 'cp /rgb-sdk/target/debug/librgb.so /opt/mount/rust-lib/target/debug/librgb.so \
     && cp /rgb-sdk/rgb_node.node /opt/mount/ffi/nodejs/build/Release/rgb_node.node'
+```
+
+## Usage
+
+To try the generated library, from the project root run:
+```bash
+cd demo/nodejs
+node example.js
 ```

--- a/ffi/nodejs/README.md
+++ b/ffi/nodejs/README.md
@@ -20,8 +20,10 @@ node example.js
 ### In docker
 
 ```bash
-docker build -f ffi/nodejs/Dockerfile -t rgb-nodejs .
-docker run -it --rm -v $(pwd):/opt/mount --entrypoint cp \
-    rgb-nodejs \
-    /rgb-node/target/debug/librgb.so /rgb-node/rgb_node.node /opt/mount/
+docker build -f ffi/nodejs/Dockerfile -t rgb-sdk-nodejs .
+mkdir -p rust-lib/target/debug ffi/nodejs/build/Release
+docker run --rm -v $(pwd):/opt/mount --entrypoint bash \
+    rgb-sdk-nodejs \
+    -c 'cp /rgb-sdk/target/debug/librgb.so /opt/mount/rust-lib/target/debug/librgb.so \
+    && cp /rgb-sdk/rgb_node.node /opt/mount/ffi/nodejs/build/Release/rgb_node.node'
 ```

--- a/ffi/nodejs/binding.gyp
+++ b/ffi/nodejs/binding.gyp
@@ -3,9 +3,15 @@
     {
       "target_name": "rgb_node",
       "sources": [ "swig_wrap.cxx" ],
-      "libraries": [ '-L<(module_root_dir)/../../target/debug/', '-lrgb'],
+      "libraries": [
+           '-L<(module_root_dir)/../../rust-lib/target/debug/',
+           '-lrgb',
+       ],
       'include_dirs': [
-          '../',
+           '../../rust-lib',
+       ],
+       "ldflags": [
+           '-Wl,-rpath,../../rust-lib/target/debug/'
        ],
       "cflags!": ["-std=c++11"],
     }

--- a/ffi/nodejs/package.json
+++ b/ffi/nodejs/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "preinstall": "cargo build && swig -javascript -node -c++ swig.i",
+    "preinstall": "cargo build --manifest-path ../../rust-lib/Cargo.toml && swig -javascript -node -c++ swig.i",
     "install": "node ./node_modules/node-gyp/bin/node-gyp.js rebuild"
   },
   "author": "",

--- a/ffi/nodejs/package.json
+++ b/ffi/nodejs/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "node-gyp": "^5.1.1"
+    "node-gyp": "^7.1.0"
   }
 }

--- a/ffi/nodejs/swig.i
+++ b/ffi/nodejs/swig.i
@@ -1,6 +1,6 @@
 %module rgb_node
 %{
-#include "../rgb_node.h"
+#include "../../rust-lib/rgb_node.h"
 %}
 
 %typemap(out) CResult (v8::Local<v8::Promise::Resolver> resolver) %{
@@ -18,4 +18,4 @@
     $result = resolver->GetPromise();
 %}
 
-%include "../rgb_node.h"
+%include "../../rust-lib/rgb_node.h"


### PR DESCRIPTION
this PR resolves a part of #2, in particular:
- fixes relative paths of Node.js integration (necessary since project structure change)
- updates `node-gyp`
- fixes Node.js bindings dockerization (and optimizes it adding the `.dockerignore` file)
- fixes Node.js bindings documentation
- partially fixes Node.js demo, adding `ldflags` to `ffi/nodejs/binding.gyp` (missing documentation on how to retrieve testnet asset data)