### PR TITLE
Actually fixed android integration

### DIFF
--- a/ffi/android/build_rust.sh
+++ b/ffi/android/build_rust.sh
@@ -26,13 +26,17 @@ swig -java -c++ -package "org.lnpbp.rgbnode_autogen" -outdir library/src/main/ja
 mkdir -p $JNILIBS/arm64-v8a $JNILIBS/x86_64 $JNILIBS/armeabi-v7a $JNILIBS/x86
 
 aarch64-linux-android21-clang++ -shared swig_wrap.cxx -L$RUSTLIB/target/aarch64-linux-android/debug/ -lrgb -o $JNILIBS/arm64-v8a/librgb_node.so -fPIC
+cp -v $RUSTLIB/target/aarch64-linux-android/debug/librgb.so $JNILIBS/arm64-v8a/
 cp -v $NDK_HOME/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_shared.so $JNILIBS/arm64-v8a/
 
 x86_64-linux-android21-clang++ -shared swig_wrap.cxx -L$RUSTLIB/target/x86_64-linux-android/debug/ -lrgb -o $JNILIBS/x86_64/librgb_node.so -fPIC
+cp -v $RUSTLIB/target/x86_64-linux-android/debug/librgb.so $JNILIBS/x86_64/
 cp -v $NDK_HOME/sources/cxx-stl/llvm-libc++/libs/x86_64/libc++_shared.so $JNILIBS/x86_64/
 
 armv7a-linux-androideabi21-clang++ -shared swig_wrap.cxx -L$RUSTLIB/target/armv7-linux-androideabi/debug/ -lrgb -o $JNILIBS/armeabi-v7a/librgb_node.so -fPIC
+cp -v $RUSTLIB/target/armv7-linux-androideabi/debug/librgb.so $JNILIBS/armeabi-v7a/
 cp -v $NDK_HOME/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so $JNILIBS/armeabi-v7a/
 
 i686-linux-android21-clang++ -shared swig_wrap.cxx -L$RUSTLIB/target/i686-linux-android/debug/ -lrgb -o $JNILIBS/x86/librgb_node.so -fPIC
+cp -v $RUSTLIB/target/i686-linux-android/debug/librgb.so $JNILIBS/x86/
 cp -v $NDK_HOME/sources/cxx-stl/llvm-libc++/libs/x86/libc++_shared.so $JNILIBS/x86/


### PR DESCRIPTION
On #6 I've removed a `cp` that I was convinced it was overriding the final library. I was wrong, probably messed up stuff during builds. The `librgb.so` is necessary, otherwise, when loading the library in the android app, this error is received:
```
I/RGB_NODE: loading library
D/AndroidRuntime: Shutting down VM
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.react_native_demo, PID: 28170
    java.lang.UnsatisfiedLinkError: dlopen failed: library "librgb.so" not found
        at java.lang.Runtime.loadLibrary0(Runtime.java:1016)
        at java.lang.System.loadLibrary(System.java:1669)
        at com.react_native_demo.MainApplication.onCreate(MainApplication.java:57)
        at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1154)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:5871)
        at android.app.ActivityThread.access$1100(ActivityThread.java:199)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1650)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```
contents of the (working) library:
```
unzip -l library/build/outputs/aar/library-debug.aar
Archive:  library/build/outputs/aar/library-debug.aar
  Length      Date    Time    Name
---------  ---------- -----   ----
    88185  1980-02-01 00:00   R.txt
      303  1980-02-01 00:00   AndroidManifest.xml
    12871  1980-02-01 00:00   classes.jar
        0  1980-02-01 00:00   jni/
        0  1980-02-01 00:00   jni/arm64-v8a/
   936368  1980-02-01 00:00   jni/arm64-v8a/libc++_shared.so
 20402312  1980-02-01 00:00   jni/arm64-v8a/librgb.so
    14168  1980-02-01 00:00   jni/arm64-v8a/librgb_node.so
        0  1980-02-01 00:00   jni/armeabi-v7a/
   558988  1980-02-01 00:00   jni/armeabi-v7a/libc++_shared.so
 12303312  1980-02-01 00:00   jni/armeabi-v7a/librgb.so
    22132  1980-02-01 00:00   jni/armeabi-v7a/librgb_node.so
        0  1980-02-01 00:00   jni/x86/
   939924  1980-02-01 00:00   jni/x86/libc++_shared.so
 28597208  1980-02-01 00:00   jni/x86/librgb.so
    13832  1980-02-01 00:00   jni/x86/librgb_node.so
        0  1980-02-01 00:00   jni/x86_64/
  1002168  1980-02-01 00:00   jni/x86_64/libc++_shared.so
 26800496  1980-02-01 00:00   jni/x86_64/librgb.so
    14440  1980-02-01 00:00   jni/x86_64/librgb_node.so
        0  1980-02-01 00:00   arm64-v8a/
        0  1980-02-01 00:00   armeabi-v7a/
        0  1980-02-01 00:00   x86/
        0  1980-02-01 00:00   x86_64/
---------                     -------
 91706707                     24 files
```