### PR TITLE
C bindings rework

### DIFF
--- a/demo/android/app/src/main/java/org/lnpbp/demoapp/MainActivity.java
+++ b/demo/android/app/src/main/java/org/lnpbp/demoapp/MainActivity.java
@@ -39,7 +39,13 @@ public class MainActivity extends AppCompatActivity {
 
                     final String consignment_file = getCacheDir().toString() + "/" + UUID.randomUUID().toString();
                     final String transaction_file = getCacheDir().toString() + "/" + UUID.randomUUID().toString();
-                    runtime.transfer(Arrays.asList("0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0"), Arrays.asList(allocation), "rgb20:outpoint1mzu8vz3jly3rzzkdpph583yahv9wktljtfcln6pe2le6n7ehqulstu967t?amount=5&asset=rgb:id1yqqqxya60n725eszngdx8yvwh3pxyk0sp9fszmzxze3nzhgm76ur4dqf2f7gy", "cHNidP8BAFICAAAAAZ38ZijCbFiZ/hvT3DOGZb/VXXraEPYiCXPfLTht7BJ2AQAAAAD/////AfA9zR0AAAAAFgAUezoAv9wU0neVwrdJAdCdpu8TNXkAAAAATwEENYfPAto/0AiAAAAAlwSLGtBEWx7IJ1UXcnyHtOTrwYogP/oPlMAVZr046QADUbdDiH7h1A3DKmBDck8tZFmztaTXPa7I+64EcvO8Q+IM2QxqT64AAIAAAACATwEENYfPAto/0AiAAAABuQRSQnE5zXjCz/JES+NTzVhgXj5RMoXlKLQH+uP2FzUD0wpel8itvFV9rCrZp+OcFyLrrGnmaLbyZnzB1nHIPKsM2QxqT64AAIABAACAAAEBKwBlzR0AAAAAIgAgLFSGEmxJeAeagU4TcV1l82RZ5NbMre0mbQUIZFuvpjIBBUdSIQKdoSzbWyNWkrkVNq/v5ckcOrlHPY5DtTODarRWKZyIcSEDNys0I07Xz5wf6l0F1EFVeSe+lUKxYusC4ass6AIkwAtSriIGAp2hLNtbI1aSuRU2r+/lyRw6uUc9jkO1M4NqtFYpnIhxENkMak+uAACAAAAAgAAAAAAiBgM3KzQjTtfPnB/qXQXUQVV5J76VQrFi6wLhqyzoAiTACxDZDGpPrgAAgAEAAIAAAAAAACICA57/H1R6HV+S36K6evaslxpL0DukpzSwMVaiVritOh75EO3kXMUAAACAAAAAgAEAAIAA", 465, "0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:2", consignment_file, transaction_file);
+                    runtime.transfer(
+                            Arrays.asList("0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0"),
+                            Arrays.asList(allocation),
+                            "rgb20:outpoint1mzu8vz3jly3rzzkdpph583yahv9wktljtfcln6pe2le6n7ehqulstu967t?amount=5&asset=rgb:id1yqqqxya60n725eszngdx8yvwh3pxyk0sp9fszmzxze3nzhgm76ur4dqf2f7gy",
+                            "cHNidP8BAFICAAAAAZ38ZijCbFiZ/hvT3DOGZb/VXXraEPYiCXPfLTht7BJ2AQAAAAD/////AfA9zR0AAAAAFgAUezoAv9wU0neVwrdJAdCdpu8TNXkAAAAATwEENYfPAto/0AiAAAAAlwSLGtBEWx7IJ1UXcnyHtOTrwYogP/oPlMAVZr046QADUbdDiH7h1A3DKmBDck8tZFmztaTXPa7I+64EcvO8Q+IM2QxqT64AAIAAAACATwEENYfPAto/0AiAAAABuQRSQnE5zXjCz/JES+NTzVhgXj5RMoXlKLQH+uP2FzUD0wpel8itvFV9rCrZp+OcFyLrrGnmaLbyZnzB1nHIPKsM2QxqT64AAIABAACAAAEBKwBlzR0AAAAAIgAgLFSGEmxJeAeagU4TcV1l82RZ5NbMre0mbQUIZFuvpjIBBUdSIQKdoSzbWyNWkrkVNq/v5ckcOrlHPY5DtTODarRWKZyIcSEDNys0I07Xz5wf6l0F1EFVeSe+lUKxYusC4ass6AIkwAtSriIGAp2hLNtbI1aSuRU2r+/lyRw6uUc9jkO1M4NqtFYpnIhxENkMak+uAACAAAAAgAAAAAAiBgM3KzQjTtfPnB/qXQXUQVV5J76VQrFi6wLhqyzoAiTACxDZDGpPrgAAgAEAAIAAAAAAACICA57/H1R6HV+S36K6evaslxpL0DukpzSwMVaiVritOh75EO3kXMUAAACAAAAAgAEAAIAA",
+                            consignment_file,
+                            transaction_file);
                 } catch (RuntimeException e) {
                     Log.e("RGB_NODE", e.getMessage());
                 }

--- a/demo/nodejs/example.js
+++ b/demo/nodejs/example.js
@@ -1,4 +1,4 @@
-const ex = require('../../ffi/nodejs/build/Release/rgb_node');
+const ex = require('../../ffi/nodejs/build/Release/rgb_node')
 
 const config = {
     network: "testnet",
@@ -8,9 +8,21 @@ const config = {
     },
     threaded: false,
     datadir: "/tmp/rgb-node/"
-};
+}
 
-ex.start_rgb(JSON.stringify(config))
+const transferData = {
+    inputs: ["0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0"],
+    allocate: [
+        { coins: 100, vout:1, txid: "0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4" }
+    ],
+    invoice: "rgb20:outpoint1mzu8vz3jly3rzzkdpph583yahv9wktljtfcln6pe2le6n7ehqulstu967t?amount=5&asset=rgb:id1yqqqxya60n725eszngdx8yvwh3pxyk0sp9fszmzxze3nzhgm76ur4dqf2f7gy",
+    prototype_psbt: "cHNidP8BAFICAAAAAZ38ZijCbFiZ/hvT3DOGZb/VXXraEPYiCXPfLTht7BJ2AQAAAAD/////AfA9zR0AAAAAFgAUezoAv9wU0neVwrdJAdCdpu8TNXkAAAAATwEENYfPAto/0AiAAAAAlwSLGtBEWx7IJ1UXcnyHtOTrwYogP/oPlMAVZr046QADUbdDiH7h1A3DKmBDck8tZFmztaTXPa7I+64EcvO8Q+IM2QxqT64AAIAAAACATwEENYfPAto/0AiAAAABuQRSQnE5zXjCz/JES+NTzVhgXj5RMoXlKLQH+uP2FzUD0wpel8itvFV9rCrZp+OcFyLrrGnmaLbyZnzB1nHIPKsM2QxqT64AAIABAACAAAEBKwBlzR0AAAAAIgAgLFSGEmxJeAeagU4TcV1l82RZ5NbMre0mbQUIZFuvpjIBBUdSIQKdoSzbWyNWkrkVNq/v5ckcOrlHPY5DtTODarRWKZyIcSEDNys0I07Xz5wf6l0F1EFVeSe+lUKxYusC4ass6AIkwAtSriIGAp2hLNtbI1aSuRU2r+/lyRw6uUc9jkO1M4NqtFYpnIhxENkMak+uAACAAAAAgAAAAAAiBgM3KzQjTtfPnB/qXQXUQVV5J76VQrFi6wLhqyzoAiTACxDZDGpPrgAAgAEAAIAAAAAAACICA57/H1R6HV+S36K6evaslxpL0DukpzSwMVaiVritOh75EO3kXMUAAACAAAAAgAEAAIAA",
+    consignment_file: "/tmp/rgb-node/output/consignment",
+    transaction_file: "/tmp/rgb-node/output/transaction"
+}
+
+ex.start_rgb(config.network, config.stash_endpoint, JSON.stringify(config.contract_endpoints), config.threaded,
+             config.datadir)
     /*.then(r => ex.issue(r, JSON.stringify({
         network: "testnet",
         ticker: "USDT",
@@ -19,14 +31,7 @@ ex.start_rgb(JSON.stringify(config))
         allocations: [{ coins: 100, vout:0, txid: "0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4" }],
         precision: 0,
     })))*/
-    .then(r => ex.transfer(r, JSON.stringify({
-        inputs: ["0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0"],
-        allocate: [
-            { coins: 100, vout:1, txid: "0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4" }
-        ],
-        invoice: "rgb20:outpoint1mzu8vz3jly3rzzkdpph583yahv9wktljtfcln6pe2le6n7ehqulstu967t?amount=5&asset=rgb:id1yqqqxya60n725eszngdx8yvwh3pxyk0sp9fszmzxze3nzhgm76ur4dqf2f7gy",
-        prototype_psbt: "cHNidP8BAFICAAAAAZ38ZijCbFiZ/hvT3DOGZb/VXXraEPYiCXPfLTht7BJ2AQAAAAD/////AfA9zR0AAAAAFgAUezoAv9wU0neVwrdJAdCdpu8TNXkAAAAATwEENYfPAto/0AiAAAAAlwSLGtBEWx7IJ1UXcnyHtOTrwYogP/oPlMAVZr046QADUbdDiH7h1A3DKmBDck8tZFmztaTXPa7I+64EcvO8Q+IM2QxqT64AAIAAAACATwEENYfPAto/0AiAAAABuQRSQnE5zXjCz/JES+NTzVhgXj5RMoXlKLQH+uP2FzUD0wpel8itvFV9rCrZp+OcFyLrrGnmaLbyZnzB1nHIPKsM2QxqT64AAIABAACAAAEBKwBlzR0AAAAAIgAgLFSGEmxJeAeagU4TcV1l82RZ5NbMre0mbQUIZFuvpjIBBUdSIQKdoSzbWyNWkrkVNq/v5ckcOrlHPY5DtTODarRWKZyIcSEDNys0I07Xz5wf6l0F1EFVeSe+lUKxYusC4ass6AIkwAtSriIGAp2hLNtbI1aSuRU2r+/lyRw6uUc9jkO1M4NqtFYpnIhxENkMak+uAACAAAAAgAAAAAAiBgM3KzQjTtfPnB/qXQXUQVV5J76VQrFi6wLhqyzoAiTACxDZDGpPrgAAgAEAAIAAAAAAACICA57/H1R6HV+S36K6evaslxpL0DukpzSwMVaiVritOh75EO3kXMUAAACAAAAAgAEAAIAA",
-        consignment_file: "/tmp/rgb-node/output/consignment",
-        transaction_file: "/tmp/rgb-node/output/transaction"
-    })))
-    .catch(e => console.log(e));
+    .then(r => ex.transfer(r, JSON.stringify(transferData.inputs), JSON.stringify(transferData.allocate),
+                           transferData.invoice, transferData.prototype_psbt, transferData.consignment_file,
+                           transferData.transaction_file))
+    .catch(e => console.log(e))

--- a/ffi/android/library/src/main/java/org/lnpbp/rgbnode/Runtime.java
+++ b/ffi/android/library/src/main/java/org/lnpbp/rgbnode/Runtime.java
@@ -21,8 +21,8 @@ public class Runtime {
 
         final StartRgbArgs args = new StartRgbArgs(network, stashEndpoint, contractEndpoints, threaded, datadir);
         try {
-            final String jsonArgs = mapper.writeValueAsString(args);
-            this.runtime = rgb_node.start_rgb(jsonArgs);
+            final String contractEndpointsStr = mapper.writeValueAsString(contractEndpoints);
+            this.runtime = rgb_node.start_rgb(network, stashEndpoint, contractEndpointsStr, threaded, datadir);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -41,8 +41,9 @@ public class Runtime {
     public void transfer(List<String> inputs, List<IssueArgs.CoinAllocation> allocate, String invoice, String prototype_psbt, String consignment_file, String transaction_file) throws RuntimeException {
         final TransferArgs args = new TransferArgs(inputs, allocate, invoice, prototype_psbt, consignment_file, transaction_file);
         try {
-            final String jsonArgs = mapper.writeValueAsString(args);
-            rgb_node.transfer(this.runtime, jsonArgs);
+            final String inputsStr = mapper.writeValueAsString(inputs);
+            final String allocateStr = mapper.writeValueAsString(allocate);
+            rgb_node.transfer(this.runtime, inputsStr, allocateStr, invoice, prototype_psbt, consignment_file, transaction_file);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
 name = "rgb"
 version = "0.1.0-rc.1"
 dependencies = [
+ "amplify_derive",
  "android_logger",
  "cbindgen",
  "env_logger",
@@ -1533,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "rgb_node"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785fc4d0353f6108d4feb0d341b95140ba68d0e16bf8af7f8865fd212e102a7"
+checksum = "3b0bd790a4fa374df1adce53a014df1db0a047dbddb209e6509825f462ec8229"
 dependencies = [
  "amplify",
  "amplify_derive",

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -15,8 +15,9 @@ cbindgen = "^0.14"
 openssl = { version = "^0.10", features = ["vendored"] }
 
 [dependencies]
+amplify_derive = "~2.0.6"
 log = "0.4"
-rgb_node = "~0.1.0"
+rgb_node = "~0.1.1"
 serde = { version = "~1.0.111", features = ["derive"] }
 serde_with = "~1.5.0"
 serde_json = "~1.0.55"

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -5,6 +5,8 @@ use std::env;
 use std::ffi::{CStr, CString};
 use std::hash::{Hash, Hasher};
 use std::os::raw::{c_char, c_void};
+use std::path;
+use std::str::FromStr;
 
 use log::{info, LevelFilter};
 
@@ -120,35 +122,41 @@ where
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct StartRgbArgs {
-    #[serde(with = "serde_with::rust::display_fromstr")]
-    network: bp::Chain,
-    #[serde(with = "serde_with::rust::display_fromstr")]
-    stash_endpoint: SocketLocator,
-    contract_endpoints: HashMap<ContractName, String>,
+fn _start_rgb(
+    network: *mut c_char,
+    stash_endpoint: *mut c_char,
+    contract_endpoints: *mut c_char,
     threaded: bool,
-    datadir: String,
-}
+    datadir: *mut c_char,
+) -> Result<Runtime, String> {
+    let c_network = unsafe { CStr::from_ptr(network) };
+    let network = bp::Chain::from_str(c_network.to_str().unwrap()).unwrap();
 
-fn _start_rgb(json: *mut c_char) -> Result<Runtime, String> {
-    let config: StartRgbArgs =
-        serde_json::from_str(ptr_to_string(json)?.as_str()).map_err(|e| format!("{:?}", e))?;
-    info!("Config: {:?}", config);
+    let c_stash_endpoint = unsafe { CStr::from_ptr(stash_endpoint) };
+    let stash_endpoint = SocketLocator::Posix(path::PathBuf::from(
+        c_stash_endpoint.to_str().unwrap().to_string(),
+    ));
+
+    let contract_endpoints: HashMap<ContractName, String> =
+        serde_json::from_str(ptr_to_string(contract_endpoints)?.as_str())
+            .map_err(|e| format!("{:?}", e))?;
+
+    let c_datadir = unsafe { CStr::from_ptr(datadir) };
+    let datadir = c_datadir.to_str().unwrap().to_string();
 
     let config = Config {
-        network: config.network,
-        stash_endpoint: config.stash_endpoint,
-        threaded: config.threaded,
-        data_dir: config.datadir,
-        contract_endpoints: config
-            .contract_endpoints
+        network: network,
+        stash_endpoint: stash_endpoint,
+        contract_endpoints: contract_endpoints
             .into_iter()
             .map(|(k, v)| -> Result<_, UrlError> { Ok((k, v.parse()?)) })
             .collect::<Result<_, _>>()
             .map_err(|e| format!("{:?}", e))?,
+        threaded: threaded,
+        data_dir: datadir,
     };
 
+    info!("{:?}", config);
     Runtime::init(config).map_err(|e| format!("{:?}", e))
 }
 
@@ -165,12 +173,25 @@ fn start_logger() {
 }
 
 #[no_mangle]
-pub extern "C" fn start_rgb(json: *mut c_char) -> CResult {
+pub extern "C" fn start_rgb(
+    network: *mut c_char,
+    stash_endpoint: *mut c_char,
+    contract_endpoints: *mut c_char,
+    threaded: bool,
+    datadir: *mut c_char,
+) -> CResult {
     start_logger();
 
     info!("Starting RGB...");
 
-    _start_rgb(json).into()
+    _start_rgb(
+        network,
+        stash_endpoint,
+        contract_endpoints,
+        threaded,
+        datadir,
+    )
+    .into()
 }
 
 #[derive(Debug, Deserialize)]
@@ -214,31 +235,49 @@ pub extern "C" fn issue(runtime: &COpaqueStruct, json: *mut c_char) -> CResult {
     _issue(runtime, json).into()
 }
 
-#[derive(Debug, Deserialize)]
-struct TransferArgs {
-    inputs: Vec<OutPoint>,
-    allocate: Vec<Outcoins>,
-    #[serde(with = "serde_with::rust::display_fromstr")]
-    invoice: Invoice,
-    prototype_psbt: String,
-    consignment_file: String,
-    transaction_file: String,
-}
-
-fn _transfer(runtime: &COpaqueStruct, json: *mut c_char) -> Result<(), String> {
+fn _transfer(
+    runtime: &COpaqueStruct,
+    inputs: *mut c_char,
+    allocate: *mut c_char,
+    invoice: *mut c_char,
+    prototype_psbt: *mut c_char,
+    consignment_file: *mut c_char,
+    transaction_file: *mut c_char,
+) -> Result<(), String> {
     let runtime = Runtime::from_opaque(runtime)?;
-    let data: TransferArgs =
-        serde_json::from_str(ptr_to_string(json)?.as_str()).map_err(|e| format!("{:?}", e))?;
-    info!("{:?}", data);
+
+    let inputs: Vec<OutPoint> =
+        serde_json::from_str(ptr_to_string(inputs)?.as_str()).map_err(|e| format!("{:?}", e))?;
+
+    let allocate: Vec<Outcoins> =
+        serde_json::from_str(ptr_to_string(allocate)?.as_str()).map_err(|e| format!("{:?}", e))?;
+
+    let c_invoice = unsafe { CStr::from_ptr(invoice) };
+    let invoice = Invoice::from_str(c_invoice.to_str().unwrap()).unwrap();
+
+    let c_prototype_psbt = unsafe { CStr::from_ptr(prototype_psbt) };
+    let prototype_psbt = c_prototype_psbt.to_str().unwrap().to_string();
+
+    let c_consignment_file = unsafe { CStr::from_ptr(consignment_file) };
+    let consignment_file = c_consignment_file.to_str().unwrap().to_string();
+
+    let c_transaction_file = unsafe { CStr::from_ptr(transaction_file) };
+    let transaction_file = c_transaction_file.to_str().unwrap().to_string();
+
+    info!(
+        "TransferArgs {{ inputs: {:?}, allocate: {:?}, invoice: {:?}, prototype_psbt: {:?}, \
+        consignment_file: {:?}, transaction_file: {:?} }}",
+        inputs, allocate, invoice, prototype_psbt, consignment_file, transaction_file
+    );
 
     runtime
         .transfer(
-            data.inputs,
-            data.allocate,
-            data.invoice,
-            data.prototype_psbt,
-            data.consignment_file,
-            data.transaction_file,
+            inputs,
+            allocate,
+            invoice,
+            prototype_psbt,
+            consignment_file,
+            transaction_file,
         )
         .map_err(|e| format!("{:?}", e))
         .map(|_| ())
@@ -246,6 +285,23 @@ fn _transfer(runtime: &COpaqueStruct, json: *mut c_char) -> Result<(), String> {
 }
 
 #[no_mangle]
-pub extern "C" fn transfer(runtime: &COpaqueStruct, json: *mut c_char) -> CResult {
-    _transfer(runtime, json).into()
+pub extern "C" fn transfer(
+    runtime: &COpaqueStruct,
+    inputs: *mut c_char,
+    allocate: *mut c_char,
+    invoice: *mut c_char,
+    prototype_psbt: *mut c_char,
+    consignment_file: *mut c_char,
+    transaction_file: *mut c_char,
+) -> CResult {
+    _transfer(
+        runtime,
+        inputs,
+        allocate,
+        invoice,
+        prototype_psbt,
+        consignment_file,
+        transaction_file,
+    )
+    .into()
 }


### PR DESCRIPTION
This PR covers one of the tasks described in #2:
>  Since transfer API is stabilized, we need to use proper arguments in c bindings (and the rest of libs) instead of encoding/decoding to JSON and passing it around

I haven't changed parameters of the `issue` function, since it will be removed from here. But I can do that if it's needed.

The rust library still uses `serde_json` to receive complex objects (like arrays or dictionaries), meaning sdk users will need to pass those objects as strings. In order to change this, some consistent changes may be necessary on demos.
For example on node.js demo we would need to use some external packages (see [here](http://jakegoulding.com/rust-ffi-omnibus/slice_arguments/)) and change how library gets loaded.
So I think that we need some good reasons to change it further than this.

Testing the changes on node.js demo I can notice some differences from the output from `master` and my branch:

- master:
```
[2020-10-26T14:01:40Z INFO  rgb] Starting RGB...
[2020-10-26T14:01:40Z INFO  rgb] Config: StartRgbArgs { network: Testnet3, stash_endpoint: Posix("/tmp/rgb-node/testnet/stashd.rpc"), contract_endpoints: {Fungible: "ipc:/tmp/rgb-node/testnet/fungibled.rpc"}, threaded: false, datadir: "/tmp/rgb-node/" }
d8b8760a32f922310acd086f43c49dbb0aeb2ff25a71f9e83957f3a9fb37073f
"Error(\"WrongOutpoint\", line: 1, column: 360)"
```

- my branch:
```
[2020-10-26T14:02:35Z INFO  rgb] Starting RGB...
[2020-10-26T14:02:35Z INFO  rgb] Config { stash_endpoint: Posix("ipc:/tmp/rgb-node/testnet/stashd.rpc"), contract_endpoints: {Fungible: Posix("/tmp/rgb-node/testnet/fungibled.rpc")}, network: Testnet3, threaded: false, data_dir: "/tmp/rgb-node/" }
d8b8760a32f922310acd086f43c49dbb0aeb2ff25a71f9e83957f3a9fb37073f
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: WrongOutpoint', src/lib.rs:233:66
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
Aborted
```

Differences on `Config` logs have already been discussed in private and should be ok.

On the new output the `WrongOutpoint` error looks too verbose to me, but I don't know how to handle error logs yet, any ideas on how to improve this?