### PR TITLE
Add accept and validate methods

### DIFF
--- a/demo/nodejs/example.js
+++ b/demo/nodejs/example.js
@@ -1,4 +1,5 @@
-const ex = require('../../ffi/nodejs/build/Release/rgb_node')
+const fs = require('fs')
+const rgbNode = require('../../ffi/nodejs/rgb_node')
 
 const config = {
     network: "testnet",
@@ -20,6 +21,8 @@ const issueData = {
     prune_seals: [],
 }
 
+const consignmentPath = '/tmp/rgb-node/output/consignment'
+
 const transferData = {
     inputs: ["0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0"],
     allocate: [
@@ -27,34 +30,36 @@ const transferData = {
     ],
     invoice: "rgb20:outpoint1mzu8vz3jly3rzzkdpph583yahv9wktljtfcln6pe2le6n7ehqulstu967t?amount=5&asset=rgb:id1yqqqxya60n725eszngdx8yvwh3pxyk0sp9fszmzxze3nzhgm76ur4dqf2f7gy",
     prototype_psbt: "cHNidP8BAFICAAAAAZ38ZijCbFiZ/hvT3DOGZb/VXXraEPYiCXPfLTht7BJ2AQAAAAD/////AfA9zR0AAAAAFgAUezoAv9wU0neVwrdJAdCdpu8TNXkAAAAATwEENYfPAto/0AiAAAAAlwSLGtBEWx7IJ1UXcnyHtOTrwYogP/oPlMAVZr046QADUbdDiH7h1A3DKmBDck8tZFmztaTXPa7I+64EcvO8Q+IM2QxqT64AAIAAAACATwEENYfPAto/0AiAAAABuQRSQnE5zXjCz/JES+NTzVhgXj5RMoXlKLQH+uP2FzUD0wpel8itvFV9rCrZp+OcFyLrrGnmaLbyZnzB1nHIPKsM2QxqT64AAIABAACAAAEBKwBlzR0AAAAAIgAgLFSGEmxJeAeagU4TcV1l82RZ5NbMre0mbQUIZFuvpjIBBUdSIQKdoSzbWyNWkrkVNq/v5ckcOrlHPY5DtTODarRWKZyIcSEDNys0I07Xz5wf6l0F1EFVeSe+lUKxYusC4ass6AIkwAtSriIGAp2hLNtbI1aSuRU2r+/lyRw6uUc9jkO1M4NqtFYpnIhxENkMak+uAACAAAAAgAAAAAAiBgM3KzQjTtfPnB/qXQXUQVV5J76VQrFi6wLhqyzoAiTACxDZDGpPrgAAgAEAAIAAAAAAACICA57/H1R6HV+S36K6evaslxpL0DukpzSwMVaiVritOh75EO3kXMUAAACAAAAAgAEAAIAA",
-    consignment_file: "/tmp/rgb-node/output/consignment",
+    consignment_file: consignmentPath,
     transaction_file: "/tmp/rgb-node/output/transaction"
 }
 
 var runtime = null
 
 async function main() {
-    await ex.start_rgb(
-        config.network, config.stash_endpoint, JSON.stringify(config.contract_endpoints), config.threaded, config.datadir)
+    await rgbNode.startRgb(
+        config.network, config.stash_endpoint, config.contract_endpoints, config.threaded, config.datadir)
     .then(r => {
         runtime = r
-        return ex.issue(runtime, JSON.stringify(issueData))
+        return rgbNode.issue(runtime, issueData)
     })
     /*
     .then(() => {
-        return ex.transfer(runtime, JSON.stringify(transferData.inputs), JSON.stringify(transferData.allocate),
+        return rgbNode.transfer(runtime, transferData.inputs, transferData.allocate,
            transferData.invoice, transferData.prototype_psbt, transferData.consignment_file,
            transferData.transaction_file)
     })
     .then(() => {
-        return ex.asset_allocations(runtime, 'rgb1w82xuaxz6lp9symrp3f4r47rylkkxsh506qzkt2n2kjfhrhrt03qrrcm0g')
+        return rgbNode.assetAllocations(runtime, 'rgb1w82xuaxz6lp9symrp3f4r47rylkkxsh506qzkt2n2kjfhrhrt03qrrcm0g')
     })
     */
     .then(() => {
-        return ex.outpoint_assets(runtime, '5aa2d0a8098371ee12b4b59f43ffe6a2de637341258af65936a5baa01da49e9b:0')
+        return rgbNode.outpointAssets(runtime, '5aa2d0a8098371ee12b4b59f43ffe6a2de637341258af65936a5baa01da49e9b:0')
     })
     .then(assets => {
         console.log('assets: ' + assets)
+        consignment = fs.readFileSync(consignmentPath)
+        return rgbNode.validate(runtime, consignment)
     })
 }
 

--- a/demo/nodejs/example.js
+++ b/demo/nodejs/example.js
@@ -8,7 +8,7 @@ const config = {
         Fungible: "lnpz:/tmp/rgb-node/testnet/fungibled.rpc"
     },
     threaded: true,
-    datadir: "/tmp/rgb-node/"
+    datadir: "/tmp/rgb-node"
 }
 
 const issueData = {
@@ -21,7 +21,7 @@ const issueData = {
     prune_seals: [],
 }
 
-const consignmentPath = '/tmp/rgb-node/output/consignment'
+const consignmentPath = '../../../rgb-node/sample/consignment.rgb'
 
 const transferData = {
     inputs: ["0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0"],
@@ -37,13 +37,15 @@ const transferData = {
 var runtime = null
 
 async function main() {
+    console.log("RGB demo")
+
     await rgbNode.startRgb(
         config.network, config.stash_endpoint, config.contract_endpoints, config.threaded, config.datadir)
     .then(r => {
+        console.log("RGB node runtime has started")
         runtime = r
-        return rgbNode.issue(runtime, issueData)
     })
-    /*
+    /*rgbNode.issue(runtime, issueData)
     .then(() => {
         return rgbNode.transfer(runtime, transferData.inputs, transferData.allocate,
            transferData.invoice, transferData.prototype_psbt, transferData.consignment_file,
@@ -52,14 +54,22 @@ async function main() {
     .then(() => {
         return rgbNode.assetAllocations(runtime, 'rgb1w82xuaxz6lp9symrp3f4r47rylkkxsh506qzkt2n2kjfhrhrt03qrrcm0g')
     })
-    */
     .then(() => {
-        return rgbNode.outpointAssets(runtime, '5aa2d0a8098371ee12b4b59f43ffe6a2de637341258af65936a5baa01da49e9b:0')
+        console.log("Querying assets")
+        return rgbNode.outpointAssets(runtime, '0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0')
     })
+    .then(res => {
+        console.log("Asset list for 0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0")
+        console.log(res)
+    })
+    */
     .then(assets => {
-        console.log('assets: ' + assets)
-        consignment = fs.readFileSync(consignmentPath)
-        return rgbNode.validate(runtime, consignment)
+        // consignment = fs.readFileSync(consignmentPath)
+        return rgbNode.validate(runtime, consignmentPath)
+    })
+    .then(res => {
+        console.log("Validation result:")
+        console.log(res)
     })
 }
 

--- a/demo/nodejs/example.js
+++ b/demo/nodejs/example.js
@@ -21,10 +21,12 @@ const issueData = {
     prune_seals: [],
 }
 
-const consignmentPath = '../../../rgb-node/sample/consignment.rgb'
+const consignmentPath = '/tmp/rgb-node/output/consignment.rgb'
+
+const inputOutpoint = '0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0'
 
 const transferData = {
-    inputs: ["0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0"],
+    inputs: [inputOutpoint],
     allocate: [
         { coins: 100, vout:1, txid: "0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4" }
     ],
@@ -37,15 +39,14 @@ const transferData = {
 var runtime = null
 
 async function main() {
-    console.log("RGB demo")
-
     await rgbNode.startRgb(
         config.network, config.stash_endpoint, config.contract_endpoints, config.threaded, config.datadir)
     .then(r => {
         console.log("RGB node runtime has started")
         runtime = r
+        return rgbNode.issue(runtime, issueData)
     })
-    /*rgbNode.issue(runtime, issueData)
+    /*
     .then(() => {
         return rgbNode.transfer(runtime, transferData.inputs, transferData.allocate,
            transferData.invoice, transferData.prototype_psbt, transferData.consignment_file,
@@ -54,26 +55,25 @@ async function main() {
     .then(() => {
         return rgbNode.assetAllocations(runtime, 'rgb1w82xuaxz6lp9symrp3f4r47rylkkxsh506qzkt2n2kjfhrhrt03qrrcm0g')
     })
-    .then(() => {
-        console.log("Querying assets")
-        return rgbNode.outpointAssets(runtime, '0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0')
-    })
-    .then(res => {
-        console.log("Asset list for 0313ba7cfcaa66029a1a63918ebc426259f00953016c461663315d1bf6b83ab4:0")
-        console.log(res)
-    })
+    .then(allocations => {
     */
+    .then(() => {
+        //console.log("Allocations: " + allocations)
+        console.log("Querying assets")
+        return rgbNode.outpointAssets(runtime, inputOutpoint)
+    })
     .then(assets => {
-        // consignment = fs.readFileSync(consignmentPath)
+        console.log("Asset list for '" + inputOutpoint + "': " + assets)
+        console.log(assets)
         return rgbNode.validate(runtime, consignmentPath)
     })
-    .then(res => {
-        console.log("Validation result:")
-        console.log(res)
+    .then(() => {
+        console.log("Validation succeded")
     })
 }
 
-main().catch( e => {
+console.log("RGB demo")
+main().catch(e => {
     console.error('ERR: ' + e)
     process.exit(1)
 })

--- a/ffi/nodejs/rgb_node.js
+++ b/ffi/nodejs/rgb_node.js
@@ -29,10 +29,10 @@ exports.outpointAssets = function (runtime, outpoint) {
     return lib.outpoint_assets(runtime, outpoint)
 }
 
-exports.accept = function (runtime, consignment, reveal_outpoints) {
-  return lib.accept(runtime, array_to_pointer(consignment), consignment.length, reveal_outpoints)
+exports.accept = function (runtime, consignment_file, reveal_outpoints) {
+  return lib.accept(runtime, consignment_file, reveal_outpoints)
 }
 
-exports.validate = function (runtime, consignment) {
-  return lib.validate(runtime, array_to_pointer(consignment), consignment.length)
+exports.validate = function (runtime, consignment_file) {
+  return lib.validate(runtime, consignment_file)
 }

--- a/ffi/nodejs/rgb_node.js
+++ b/ffi/nodejs/rgb_node.js
@@ -1,0 +1,38 @@
+const lib = require('./build/Release/rgb_node')
+
+function array_to_pointer(js_array) {
+  cpp_pointer = lib.uint_array(js_array.length)
+  for (var i=0; i<js_array.length; i++) {
+    lib.uint_array_set(cpp_pointer, i, js_array[i])
+  }
+  return cpp_pointer
+}
+
+exports.startRgb = function (network, stashEndpoint, contractEndpoints, threaded, dataDir) {
+  return lib.start_rgb(network, stashEndpoint, JSON.stringify(contractEndpoints), threaded, dataDir)
+}
+
+exports.issue = function (runtime, issueData) {
+  return lib.issue(runtime, JSON.stringify(issueData))
+}
+
+exports.transfer = function (runtime, inputs, allocate, invoice, prototypePsbt, consignmentFile, transactionFile) {
+  return lib.transfer(
+    runtime, JSON.stringify(inputs), JSON.stringify(allocate), invoice, prototypePsbt, consignmentFile, transactionFile)
+}
+
+exports.assetAllocations = function (runtime, contractId) {
+    return lib.asset_allocations(runtime, contractId)
+}
+
+exports.outpointAssets = function (runtime, outpoint) {
+    return lib.outpoint_assets(runtime, outpoint)
+}
+
+exports.accept = function (runtime, consignment, reveal_outpoints) {
+  return lib.accept(runtime, array_to_pointer(consignment), consignment.length, reveal_outpoints)
+}
+
+exports.validate = function (runtime, consignment) {
+  return lib.validate(runtime, array_to_pointer(consignment), consignment.length)
+}

--- a/ffi/nodejs/swig.i
+++ b/ffi/nodejs/swig.i
@@ -29,4 +29,17 @@
     $result = resolver->GetPromise();
 %}
 
+%inline %{
+    uint8_t *uint_array(int size) {
+        return (uint8_t *) malloc(size*sizeof(uint8_t));
+    }
+    void uint_array_set(uint8_t *a, int i, int val) {
+        a[i] = val;
+    }
+    // for debugging purposes
+    int uint_array_get(uint8_t *a, int i) {
+        return a[i];
+    }
+%}
+
 %include "../../rust-lib/rgb_node.h"

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -95,7 +95,7 @@ fn string_to_ptr(other: String) -> *const c_char {
     cstr.into_raw()
 }
 
-fn ptr_to_string(ptr: *mut c_char) -> Result<String, RequestError> {
+fn ptr_to_string(ptr: *const c_char) -> Result<String, RequestError> {
     unsafe { Ok(CStr::from_ptr(ptr).to_string_lossy().into_owned()) }
 }
 
@@ -207,11 +207,11 @@ enum RequestError {
 }
 
 fn _start_rgb(
-    network: *mut c_char,
+    network: *const c_char,
     stash_rpc_endpoint: *const c_char,
-    contract_endpoints: *mut c_char,
+    contract_endpoints: *const c_char,
     threaded: bool,
-    datadir: *mut c_char,
+    datadir: *const c_char,
 ) -> Result<Runtime, RequestError> {
     let c_network = unsafe { CStr::from_ptr(network) };
     let network = bp::Chain::from_str(c_network.to_str()?)?;
@@ -299,11 +299,11 @@ fn _start_logger() {
 
 #[no_mangle]
 pub extern "C" fn start_rgb(
-    network: *mut c_char,
+    network: *const c_char,
     stash_rpc_endpoint: *const c_char,
-    contract_endpoints: *mut c_char,
+    contract_endpoints: *const c_char,
     threaded: bool,
-    datadir: *mut c_char,
+    datadir: *const c_char,
 ) -> CResult {
     _start_logger();
 
@@ -349,7 +349,7 @@ struct IssueArgs {
 
 fn _issue(
     runtime: &COpaqueStruct,
-    json: *mut c_char,
+    json: *const c_char,
 ) -> Result<(), RequestError> {
     let runtime = Runtime::from_opaque(runtime)?;
     let data: IssueArgs = serde_json::from_str(&ptr_to_string(json)?)?;
@@ -370,18 +370,21 @@ fn _issue(
 }
 
 #[no_mangle]
-pub extern "C" fn issue(runtime: &COpaqueStruct, json: *mut c_char) -> CResult {
+pub extern "C" fn issue(
+    runtime: &COpaqueStruct,
+    json: *const c_char,
+) -> CResult {
     _issue(runtime, json).into()
 }
 
 fn _transfer(
     runtime: &COpaqueStruct,
-    inputs: *mut c_char,
-    allocate: *mut c_char,
-    invoice: *mut c_char,
-    prototype_psbt: *mut c_char,
-    consignment_file: *mut c_char,
-    transaction_file: *mut c_char,
+    inputs: *const c_char,
+    allocate: *const c_char,
+    invoice: *const c_char,
+    prototype_psbt: *const c_char,
+    consignment_file: *const c_char,
+    transaction_file: *const c_char,
 ) -> Result<(), RequestError> {
     let runtime = Runtime::from_opaque(runtime)?;
 
@@ -423,12 +426,12 @@ fn _transfer(
 #[no_mangle]
 pub extern "C" fn transfer(
     runtime: &COpaqueStruct,
-    inputs: *mut c_char,
-    allocate: *mut c_char,
-    invoice: *mut c_char,
-    prototype_psbt: *mut c_char,
-    consignment_file: *mut c_char,
-    transaction_file: *mut c_char,
+    inputs: *const c_char,
+    allocate: *const c_char,
+    invoice: *const c_char,
+    prototype_psbt: *const c_char,
+    consignment_file: *const c_char,
+    transaction_file: *const c_char,
 ) -> CResult {
     _transfer(
         runtime,
@@ -494,7 +497,7 @@ fn _accept(
     runtime: &COpaqueStruct,
     consignment_bytes: *const u8,
     consignment_length: c_int,
-    reveal_outpoints: *mut c_char,
+    reveal_outpoints: *const c_char,
 ) -> Result<(), RequestError> {
     let runtime = Runtime::from_opaque(runtime)?;
 
@@ -524,7 +527,7 @@ pub extern "C" fn accept(
     runtime: &COpaqueStruct,
     consignment_bytes: *const u8,
     consignment_length: c_int,
-    reveal_outpoints: *mut c_char,
+    reveal_outpoints: *const c_char,
 ) -> CResult {
     _accept(
         runtime,

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -13,14 +13,14 @@ use serde::Deserialize;
 
 use rgb::lnpbp::bitcoin::OutPoint;
 use rgb::lnpbp::bp;
-use rgb::lnpbp::rgb::{ContractId, FromBech32};
 use rgb::lnpbp::rgb::Consignment;
+use rgb::lnpbp::rgb::{ContractId, FromBech32};
 
 use rgb::fungible::{Invoice, IssueStructure, Outcoins};
 use rgb::i9n::{Config, Runtime};
 use rgb::rgbd::ContractName;
-use rgb::util::SealSpec;
 use rgb::util::file::ReadWrite;
+use rgb::util::SealSpec;
 
 #[macro_use]
 extern crate amplify;
@@ -527,12 +527,7 @@ pub extern "C" fn accept(
     consignment_file: *const c_char,
     reveal_outpoints: *const c_char,
 ) -> CResult {
-    _accept(
-        runtime,
-        consignment_file,
-        reveal_outpoints,
-    )
-    .into()
+    _accept(runtime, consignment_file, reveal_outpoints).into()
 }
 
 fn _validate(


### PR DESCRIPTION
this PR is needed in order to complete the task

> Add validate and accept functions to support acceptance of transfers

defined in LNP-BP/rgb-sdk#2

~~N.B. this is a draft because first LNP-BP/rust-lnpbp#146 needs to be merged and then rust-lnpbp will need a new release~~

N.B to merge this we need to do a release of rgb-node (containing LNP-BP/rgb-node#99)