### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ plus some sample applications.
 ## Building RGB SDK
 
 First, you'll need to [install Rust](https://www.rust-lang.org/tools/install),
-then follow the instructions specific to your language binding of choice.
+then clone this project (`git clone https://github.com/LNP-BP/rgb-sdk.git`),
+go to the project root (`cd rgb-sdk`) and, finally, follow the instructions
+specific to your language binding of choice.
 
 ### Language bindings
 

--- a/ffi/android/README.md
+++ b/ffi/android/README.md
@@ -2,8 +2,9 @@
 
 ## Build
 
-In order to build Android bindings, from the project root follow the
-[Local](#local) or [In docker](#in-docker) instructions.
+In order to build Android bindings, first follow
+[main README's instructions](/README.md) and then, from the project root,
+follow the [Local](#local) or [In docker](#in-docker) instructions.
 
 Both instructions will generate the artifacts (`library-debug.aar` and
 `library-release.aar`) in `ffi/android/library/build/outputs/aar/`.

--- a/ffi/ios/README.md
+++ b/ffi/ios/README.md
@@ -3,7 +3,8 @@
 ## Build
 
 In order to include RGB into iPhone, iPad or Mac application, on Mac OS,
-from the project root, run:
+first follow [main README's instructions](/README.md) and then, from the
+project root, run:
 
 ```bash
 # install dependencies

--- a/ffi/nodejs/README.md
+++ b/ffi/nodejs/README.md
@@ -2,8 +2,9 @@
 
 ## Build
 
-In order to build Node.js bindings, from the project root follow the
-[Local](#local) or [In docker](#in-docker) instructions.
+In order to build Node.js bindings, first follow
+[main README's instructions](/README.md) and then, from the project root,
+follow the [Local](#local) or [In docker](#in-docker) instructions.
 
 Both instructions will generate the files `librgb.so` in `rust-lib/target/debug/`
 and `rgb_node.node` in `ffi/nodejs/build/Release/`.


### PR DESCRIPTION
this PR adds the `git clone` command to the main README, since it's a common requirement of all language bindings

it also adds a pointer to the main README's instructions on each language binding's README, to prevent the user from skipping an important part of the procedure